### PR TITLE
Export MapShape enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
     MapT,
     Typelike,
     MapOptions,
+    MapShape,
     SetTypeDescriptor,
     ArrayTypeDescriptor,
     MapTypeDescriptor,


### PR DESCRIPTION
The enum `MapShape` is currently not exported in `index.ts`, so it cannot be used when setting `MapOptions` for `Map` fields.