### PR TITLE
MappedTypeConverters should be available as a type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
     JsonTypes,
     defaultTypeResolver,
     defaultTypeEmitter,
+    MappedTypeConverters
 } from './parser';
 export {TypeResolver, TypeHintEmitter, JsonObjectMetadata} from './metadata';
 export {


### PR DESCRIPTION
MappedTypeConverters is currently not exported, but available to developers when setting global mappings
https://github.com/JohnWeisz/TypedJSON/blob/6f886ae669c351c6dfc3d02e853bc6294cf3d054/src/parser.ts#L320