### PR TITLE
Add explicit `return undefined`

### DIFF
--- a/spec/helpers/matchers.ts
+++ b/spec/helpers/matchers.ts
@@ -96,7 +96,7 @@ beforeEach(() => {
         const secondAsInt8Array: Int8Array | undefined = tryAsInt8Array(second);
 
         if (firstAsInt8Array === undefined || secondAsInt8Array === undefined) {
-            return;
+            return undefined;
         }
 
         if (firstAsInt8Array.length !== secondAsInt8Array.length) {
@@ -112,6 +112,7 @@ function tryAsInt8Array(obj: any): Int8Array | undefined {
     } else if (ArrayBuffer.isView(obj)) {
         return new Int8Array(obj.buffer);
     }
+    return undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -20,6 +20,7 @@ export function defaultTypeResolver(
     if (sourceObject.__type != null) {
         return knownTypes.get(sourceObject.__type);
     }
+    return undefined;
 }
 
 export type DeserializerFn<T, TD extends TypeDescriptor, Raw> = (

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -112,7 +112,7 @@ export class JsonObjectMetadata {
     static getFromConstructor<T>(ctor: Serializable<T>): JsonObjectMetadata | undefined {
         const prototype = ctor.prototype;
         if (prototype == null) {
-            return;
+            return undefined;
         }
 
         let metadata: JsonObjectMetadata | undefined;
@@ -133,6 +133,8 @@ export class JsonObjectMetadata {
             // we do not store the metadata here to not modify builtin prototype
             return primitiveMeta;
         }
+
+        return undefined;
     }
 
     static ensurePresentInPrototype(prototype: IndexedObject): JsonObjectMetadata {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -467,6 +467,7 @@ export class TypedJSON<T> {
         } catch (e) {
             this.errorHandler(e);
         }
+        return undefined;
     }
 
     toPlainArray(object: Array<T>, dimensions?: 1): Array<Object>;
@@ -489,6 +490,7 @@ export class TypedJSON<T> {
         } catch (e) {
             this.errorHandler(e);
         }
+        return undefined;
     }
 
     toPlainSet(object: Set<T>): Array<Object> | undefined {
@@ -497,6 +499,7 @@ export class TypedJSON<T> {
         } catch (e) {
             this.errorHandler(e);
         }
+        return undefined;
     }
 
     toPlainMap<K>(
@@ -511,6 +514,7 @@ export class TypedJSON<T> {
         } catch (e) {
             this.errorHandler(e);
         }
+        return undefined;
     }
 
     /**

--- a/tsconfig/tsconfig.app-strict.json
+++ b/tsconfig/tsconfig.app-strict.json
@@ -1,6 +1,13 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strict": true,
+    "allowJs": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "preserveConstEnums": true
   }
 }


### PR DESCRIPTION
Adding explicit `return undefined` in the cases where `undefined` is returned implicitly improves clarity, and removes compiler error when "noImplicitReturns" is true.

Compiler options have also been made stricter for tsconfig.app-strict.